### PR TITLE
Eclipse Vert.x support

### DIFF
--- a/java11/README.md
+++ b/java11/README.md
@@ -65,6 +65,8 @@ To switch to an Open JDK 11 in a Cloud shell session, you can use:
  - [kotlin-ktor](kotlin-ktor)
  - [spanner](spanner)
  - [bigquery](bigquery)
+ - [vertx-hello](vertx-hello)
+ - [vertx-cloudsql-postgres](vertx-cloudsql-postgres)
 
 ### appengine-simple-jetty-main
 

--- a/java11/pom.xml
+++ b/java11/pom.xml
@@ -51,5 +51,6 @@
     <module>springboot-thin</module>
     <module>kotlin-ktor</module>
     <module>vertx-hello</module>
+    <module>vertx-cloudsql-postgres</module>
   </modules>
 </project>

--- a/java11/pom.xml
+++ b/java11/pom.xml
@@ -50,5 +50,6 @@
     <module>springboot-springcloudgcp</module>
     <module>springboot-thin</module>
     <module>kotlin-ktor</module>
+    <module>vertx-hello</module>
   </modules>
 </project>

--- a/java11/vertx-cloudsql-postgres/README.md
+++ b/java11/vertx-cloudsql-postgres/README.md
@@ -1,0 +1,107 @@
+# Vertx Postgres SQL sample for Google App Engine Java11
+
+This sample demonstrates how to use [PostgreSql](https://cloud.google.com/sql/) on Google App Engine standard Java 11
+using Eclipse Vert.x and the reactive PostgreSQL client
+
+## Setup
+
+* If you haven't already, Download and initialize the [Cloud SDK](https://cloud.google.com/sdk/)
+
+    `gcloud init`
+
+
+* If you are using the Google Cloud Shell, change the default JDK to Java11:
+
+```
+   sudo update-alternatives --config java
+   # And select the usr/lib/jvm/java-11-openjdk-amd64/bin/java version.
+   # Also, set the JAVA_HOME variable for Maven to pick the correct JDK:
+   export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
+```
+
+* If you haven't already, Create an App Engine app within the current Google Cloud Project
+
+    `gcloud app create`
+
+* If you haven't already, Setup [Application Default Credentials](https://developers.google.com/identity/protocols/application-default-credentials)
+
+    `gcloud auth application-default login`
+
+
+* [Create an instance](https://cloud.google.com/sql/docs/postgres/create-instance)
+
+* [Create a Database](https://cloud.google.com/sql/docs/postgres/create-manage-databases)
+
+* [Create a user](https://cloud.google.com/sql/docs/postgres/create-manage-users)
+
+* Note the **Instance connection name** under Overview > properties
+
+## Configuring the Env Variables in app.yaml
+
+Edit the [app.yaml](src/mail/appengine/app.yaml) file and change the 4 env variables to match your environment:
+
+```
+env_variables:
+  DB_INSTANCE: PROJECT:us-central1:instance
+  DB_DATABASE: DBname
+  DB_USER: postgres
+  DB_PASSWORD: password
+```
+
+## Deploying
+
+```bash
+ mvn clean package appengine:deploy -Dapp.deploy.projectId=<your-project-id>
+```
+
+## See the application page
+
+Navigate to http://yourprojectid.appspot.com URL.
+
+## The application
+
+The application is written to use Eclipse Vert.x to demonstrate the use of [Vert.x Web](https://vertx.io/docs/vertx-web/java/) as web server
+and the [Reactive PostgreSQL client](https://github.com/reactiverse/reactive-pg-client) to access a PostgreSQL instance managed by Google Cloud SQL.
+
+Vert.x is a fully non-blocking toolkit and some parts of the application use callbacks.
+
+The PostgreSQL client is configured to connect to the instance using unix domain sockets configured with the `app.yaml` file.
+
+The [main](src/main/java/com/google/appengine/vertxcloudsqlpostgres/Main.java) class creates the Vert.x instance deploys the `Application` class:
+
+```
+Vertx vertx = Vertx.vertx();
+vertx.deployVerticle(new Application());
+```
+
+When the [application](src/main/java/com/google/appengine/vertxcloudsqlpostgres/Application.java) starts
+
+- it creates a Reactive PostgreSQL Client for querying the Cloud SQL instance
+- it creates a Vert.x Web router when it starts and initializes it to serve all the routes with the `handleDefault` method
+- it starts an HTTP server on the port `8080`
+
+```
+PgPoolOptions options = new PgPoolOptions()
+    .setUser(DB_USER)
+    .setPassword(DB_PASSWORD)
+    .setDatabase(DB_NAME)
+    .setPort(DB_PORT)
+    .setHost(DB_UNIX_DOMAIN_SOCKET);
+
+pgClient = PgClient.pool(vertx, options);
+
+Router router = Router.router(vertx);
+
+router.route().handler(this::handleDefault);
+
+vertx.createHttpServer()
+    .requestHandler(router)
+    .listen(8080, ar -> startFuture.handle(ar.mapEmpty()));
+```
+
+HTTP requests are served by the `handleDefault` method. This method uses the `PgClient` to query the PostgreSQL instance
+and return a list of all the tables found in the database.
+
+## Cleaning up
+
+* [Delete your Instance](https://cloud.google.com/sql/docs/postgres/delete-instance)

--- a/java11/vertx-cloudsql-postgres/pom.xml
+++ b/java11/vertx-cloudsql-postgres/pom.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright 2019 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.google.appengine.vertxdemo</groupId>
+  <artifactId>vertx-cloudsql-postgres-j11</artifactId>
+  <version>1.0</version>
+  <properties>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-core</artifactId>
+      <version>3.6.3</version>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-web</artifactId>
+      <version>3.6.3</version>
+    </dependency>
+    <dependency>
+      <groupId>io.reactiverse</groupId>
+      <artifactId>reactive-pg-client</artifactId>
+      <version>0.11.1</version>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-transport-native-epoll</artifactId>
+      <classifier>linux-x86_64</classifier>
+      <version>4.1.30.Final</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>1.7.22</version>
+      <type>jar</type>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>single</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <descriptorRefs>
+            <descriptorRef>jar-with-dependencies</descriptorRef>
+          </descriptorRefs>
+          <archive>
+            <manifest>
+              <mainClass>com.google.appengine.vertxcloudsqlpostgres.Main</mainClass>
+            </manifest>
+          </archive>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <version>1.6.0</version>
+        <configuration>
+          <mainClass>com.google.appengine.sparkdemo.Main</mainClass>
+          <arguments>
+            <argument>-jar</argument>
+            <argument>${app.stage.stagingDirectory}/vertx-cloudsql-postgres-j11-1.0-jar-with-dependencies.jar</argument>
+          </arguments>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>com.google.cloud.tools</groupId>
+        <artifactId>appengine-maven-plugin</artifactId>
+        <version>2.0.0-rc5</version>
+        <configuration>
+          <artifact>${project.build.directory}/vertx-cloudsql-postgres-j11-1.0-jar-with-dependencies.jar</artifact>
+	  <version>vertx-cloudsql-postgres-java11</version>
+	  <promote>false</promote>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/java11/vertx-cloudsql-postgres/src/main/appengine/app.yaml
+++ b/java11/vertx-cloudsql-postgres/src/main/appengine/app.yaml
@@ -1,0 +1,9 @@
+runtime: java11
+instance_class: F4
+# The entry point is necessary to tell Vert.x where to store cached resources extracted from fat jars
+entrypoint: 'java -Dvertx.cacheDirBase=/tmp -jar vertx-cloudsql-postgres-j11-1.0-jar-with-dependencies.jar '
+env_variables:
+  DB_INSTANCE: gae11test:europe-west1:postgres-server
+  DB_DATABASE: postgres
+  DB_USER: postgres
+  DB_PASSWORD: password

--- a/java11/vertx-cloudsql-postgres/src/main/java/com/google/appengine/vertxcloudsqlpostgres/Application.java
+++ b/java11/vertx-cloudsql-postgres/src/main/java/com/google/appengine/vertxcloudsqlpostgres/Application.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2019 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.appengine.vertxcloudsqlpostgres;
+
+import io.reactiverse.pgclient.PgClient;
+import io.reactiverse.pgclient.PgPoolOptions;
+import io.reactiverse.pgclient.PgRowSet;
+import io.reactiverse.pgclient.Row;
+import io.vertx.core.AbstractVerticle;
+import io.vertx.core.Future;
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.RoutingContext;
+
+public class Application extends AbstractVerticle {
+
+  private static final String CLOUD_SQL_INSTANCE_NAME = System.getenv("DB_INSTANCE");
+  private static final String DB_USER = System.getenv("DB_USER");
+  private static final String DB_PASSWORD = System.getenv("DB_PASSWORD");
+  private static final String DB_NAME = System.getenv("DB_DATABASE");
+  private static final String DB_UNIX_DOMAIN_SOCKET = "/cloudsql/" + CLOUD_SQL_INSTANCE_NAME;
+  private static final int DB_PORT = 5432;
+
+  private PgClient pgClient;
+
+  @Override
+  public void start(Future<Void> startFuture) {
+
+    PgPoolOptions options = new PgPoolOptions()
+        .setUser(DB_USER)
+        .setPassword(DB_PASSWORD)
+        .setDatabase(DB_NAME)
+        .setPort(DB_PORT)
+        .setHost(DB_UNIX_DOMAIN_SOCKET);
+
+    pgClient = PgClient.pool(vertx, options);
+
+    Router router = Router.router(vertx);
+
+    router.route().handler(this::handleDefault);
+
+    vertx.createHttpServer()
+        .requestHandler(router)
+        .listen(8080, ar -> startFuture.handle(ar.mapEmpty()));
+  }
+
+  private void handleDefault(RoutingContext routingContext) {
+    pgClient.query("select * from information_schema.tables", res -> {
+      if (res.succeeded()) {
+        PgRowSet rows = res.result();
+        StringBuilder result = new StringBuilder("List of all tables in your Cloud SQL:");
+        for (Row row : rows) {
+          result
+              .append("\r\n")
+              .append(row.getString("table_schema"))
+              .append(".")
+              .append(row.getString("table_name"));
+        }
+        routingContext.response()
+            .putHeader("content-type", "text/plain")
+            .end(result.toString());
+      } else {
+        routingContext.fail(res.cause());
+      }
+    });
+  }
+}

--- a/java11/vertx-cloudsql-postgres/src/main/java/com/google/appengine/vertxcloudsqlpostgres/Main.java
+++ b/java11/vertx-cloudsql-postgres/src/main/java/com/google/appengine/vertxcloudsqlpostgres/Main.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.appengine.vertxcloudsqlpostgres;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.VertxOptions;
+
+public class Main {
+
+  /**
+   * Starts the webapp on localhost:8080.
+   */
+  public static void main(String[] args) {
+
+    Vertx vertx = Vertx.vertx(new VertxOptions().setPreferNativeTransport(true));
+    vertx.deployVerticle(new Application());
+  }
+}

--- a/java11/vertx-hello/README.md
+++ b/java11/vertx-hello/README.md
@@ -1,0 +1,85 @@
+# Vertx Hello World Google App Engine Java 11 Standard Application
+
+## Setup
+
+Before running and deploying this sample, take the following steps:
+
+**App Engine Java 11 private Alpha** Please, become part of the App Engine [Alpha program](https://docs.google.com/forms/d/e/1FAIpQLSf5uE5eknJjFEmcVBI6sMitBU0QQ1LX_J7VrA_OTQabo6EEEw/viewform) for Java11 and wait for approval.
+
+**App Engine Project** Use the [GCP Console](https://console.cloud.google.com/projectselector/appengine/create?lang=java) to create a new App Engine application
+You can skip this if you already have an App Engine Project.
+
+**Cloud SDK** Download and configure the Google Cloud SDK from [here](https://cloud.google.com/sdk).
+
+Configure the gcloud command-line environment:
+
+```
+gcloud init
+gcloud auth application-default login
+```
+
+If you are using the Google Cloud Shell, change the default JDK to Java11:
+
+```
+   sudo update-alternatives --config java
+   # And select the usr/lib/jvm/java-11-openjdk-amd64/bin/java version.
+   # Also, set the JAVA_HOME variable for Maven to pick the correct JDK:
+   export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
+```
+
+## Deploying
+
+```bash
+ mvn clean package appengine:deploy -Dapp.deploy.projectId=<your-project-id>
+```
+
+## See the application page
+Navigate to http://yourprojectid.appspot.com URL.
+
+## The application
+
+The application is written to use Eclipse Vert.x to demonstrate the use of [Vert.x Web](https://vertx.io/docs/vertx-web/java/) as web server
+and [Vert.x Web client](https://vertx.io/docs/vertx-web-client/java/).
+
+Vert.x is a fully non-blocking toolkit and some parts of the application use callbacks.
+
+The [main](src/main/java/com/google/appengine/vertxhello/Main.java) class creates the Vert.x instance deploys the `Server` class:
+
+```
+Vertx vertx = Vertx.vertx();
+vertx.deployVerticle(new Server());
+```
+
+## The application
+
+When the [application](src/main/java/com/google/appengine/vertxhello/Application.java) starts
+
+- it creates a Vert.x Web client for querying the Google metadata API for the project ID displayed in the response
+- it creates a Vert.x Web router when it starts and initializes it to serve all the routes with the `handleDefault` method
+- it starts an HTTP server on the port `8080`
+
+```
+webClient = WebClient.create(vertx);
+
+Router router = Router.router(vertx);
+
+router.route().handler(this::handleDefault);
+
+vertx.createHttpServer()
+    .requestHandler(router)
+    .listen(8080, ar -> startFuture.handle(ar.mapEmpty()));
+```
+
+HTTP requests are served by the `handleDefault` method. This method uses the `WebClient` to query the Google metadata API
+for the project ID and returns an _Hello World_ string that contains the project ID name.
+
+## Testing
+
+The application is tested with a simple JUnit [test](src/test/java/com/google/appengine/vertxhello/ApplicationTest.java).
+
+The test starts two HTTP servers before running the actual test.
+
+1. the server is started on port 8080
+2. a mock Google metadata server is started on port 8081
+
+The test uses the `WebClient` to query the HTTP server on port 8080 and check the response before completing the test.

--- a/java11/vertx-hello/pom.xml
+++ b/java11/vertx-hello/pom.xml
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright 2019 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.google.appengine.vertxdemo</groupId>
+  <artifactId>vertx-hello-j11</artifactId>
+  <version>1.0</version>
+  <properties>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-core</artifactId>
+      <version>3.6.3</version>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-web</artifactId>
+      <version>3.6.3</version>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-web-client</artifactId>
+      <version>3.6.3</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>1.7.22</version>
+      <type>jar</type>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.12</version>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-unit</artifactId>
+      <version>3.6.3</version>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>single</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <descriptorRefs>
+            <descriptorRef>jar-with-dependencies</descriptorRef>
+          </descriptorRefs>
+          <archive>
+            <manifest>
+              <mainClass>com.google.appengine.vertxhello.Main</mainClass>
+            </manifest>
+          </archive>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <version>1.6.0</version>
+        <configuration>
+          <mainClass>com.google.appengine.sparkdemo.Main</mainClass>
+          <arguments>
+            <argument>-jar</argument>
+            <argument>${app.stage.stagingDirectory}/vertx-hello-j11-1.0-jar-with-dependencies.jar</argument>
+          </arguments>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>com.google.cloud.tools</groupId>
+        <artifactId>appengine-maven-plugin</artifactId>
+        <version>2.0.0-rc5</version>
+        <configuration>
+          <artifact>${project.build.directory}/vertx-hello-j11-1.0-jar-with-dependencies.jar</artifact>
+	  <version>vertx-hello-java11</version>
+	  <promote>false</promote>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/java11/vertx-hello/src/main/appengine/app.yaml
+++ b/java11/vertx-hello/src/main/appengine/app.yaml
@@ -1,0 +1,4 @@
+runtime: java11
+instance_class: F4
+# The entry point is necessary to tell Vert.x where to store cached resources extracted from fat jars
+entrypoint: 'java -Dvertx.cacheDirBase=/tmp -jar vertx-hello-j11-1.0-jar-with-dependencies.jar '

--- a/java11/vertx-hello/src/main/java/com/google/appengine/vertxhello/Application.java
+++ b/java11/vertx-hello/src/main/java/com/google/appengine/vertxhello/Application.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2019 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.appengine.vertxhello;
+
+import io.vertx.core.AbstractVerticle;
+import io.vertx.core.Future;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.client.HttpResponse;
+import io.vertx.ext.web.client.WebClient;
+import io.vertx.ext.web.client.predicate.ResponsePredicate;
+
+public class Application extends AbstractVerticle {
+
+  static String METADATA_HOST = "metadata.google.internal";
+  static int METADATA_PORT = 80;
+  WebClient webClient;
+
+  @Override
+  public void start(Future<Void> startFuture) {
+
+    webClient = WebClient.create(vertx);
+
+    Router router = Router.router(vertx);
+
+    router.route().handler(this::handleDefault);
+
+    vertx.createHttpServer()
+        .requestHandler(router)
+        .listen(8080, ar -> startFuture.handle(ar.mapEmpty()));
+  }
+
+  private void handleDefault(RoutingContext routingContext) {
+    webClient
+        .get(METADATA_PORT, METADATA_HOST, "/computeMetadata/v1/project/project-id")
+        .putHeader("Metadata-Flavor", "Google")
+        .expect(ResponsePredicate.SC_OK)
+        .send(res -> {
+          if (res.succeeded()) {
+            HttpResponse<Buffer> response = res.result();
+            routingContext.response()
+                .putHeader("content-type", "text/html")
+                .end("Hello World! from " + response.body());
+          } else {
+            routingContext.fail(res.cause());
+          }
+        });
+  }
+}

--- a/java11/vertx-hello/src/main/java/com/google/appengine/vertxhello/Main.java
+++ b/java11/vertx-hello/src/main/java/com/google/appengine/vertxhello/Main.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2019 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.appengine.vertxhello;
+
+import io.vertx.core.Vertx;
+
+public class Main {
+
+  /**
+   * Starts the webapp on localhost:8080.
+   */
+  public static void main(String[] args) {
+
+    Vertx vertx = Vertx.vertx();
+    vertx.deployVerticle(new Application());
+  }
+}

--- a/java11/vertx-hello/src/test/java/com/google/appengine/vertxhello/ApplicationTest.java
+++ b/java11/vertx-hello/src/test/java/com/google/appengine/vertxhello/ApplicationTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2019 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.appengine.vertxhello;
+
+import io.vertx.core.Vertx;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.ext.web.client.WebClient;
+import io.vertx.ext.web.client.predicate.ResponsePredicate;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(VertxUnitRunner.class)
+public class ApplicationTest {
+
+  private static Vertx vertx;
+
+  @BeforeClass
+  public static void setUp(TestContext ctx) {
+    vertx = Vertx.vertx();
+    startMetadataServer(ctx);
+    vertx.deployVerticle(new Application(), ctx.asyncAssertSuccess());
+  }
+
+  // Start a mock metadata server
+  private static void startMetadataServer(TestContext ctx) {
+    Application.METADATA_HOST = "localhost";
+    Application.METADATA_PORT = 8081;
+    vertx.createHttpServer().requestHandler(req -> {
+      req.response().end("this-is-your-project");
+    }).listen(8081, ctx.asyncAssertSuccess());
+  }
+
+  @AfterClass
+  public static void tearDown(TestContext ctx) {
+    vertx.close(ctx.asyncAssertSuccess());
+  }
+
+  @Test
+  public void test(TestContext ctx) {
+    WebClient client = WebClient.create(vertx);
+    client.get(8080, "localhost", "/")
+        .expect(ResponsePredicate.SC_OK)
+        .send(ctx.asyncAssertSuccess(response -> {
+          ctx.assertEquals("Hello World! from this-is-your-project" , response.bodyAsString());
+        }));
+  }
+}


### PR DESCRIPTION
Support for GAE 11 samples with Vert.x providing support for a basic _hello world_ app and a _Cloud SQL Postgres_ app with the reactive postgres client