### PR TITLE
Add eclipse, gradle and output folders to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 *.iml
 target/
 .idea/
+.gradle/
+bin/
+.settings/
+.classpath
+.project


### PR DESCRIPTION
Add `eclipse`, `gradle` and output (e.g. `bin`) folders to `.gitignore`