### PR TITLE
More usage of the var keyword

### DIFF
--- a/java11/smallest-sample/Main.java
+++ b/java11/smallest-sample/Main.java
@@ -22,11 +22,11 @@ import java.net.InetSocketAddress;
 public class Main {
 
   public static void main(String[] args) throws IOException {
-    HttpServer server = HttpServer.create(new InetSocketAddress(8080), 0);
-    server.createContext("/", (var t) -> {
-      byte[] response = "Hello World from Google App Engine Java 11.".getBytes();
+    var server = HttpServer.create(new InetSocketAddress(8080), 0);
+    server.createContext("/", t -> {
+      var response = "Hello World from Google App Engine Java 11.".getBytes();
       t.sendResponseHeaders(200, response.length);
-      try (OutputStream os = t.getResponseBody()) {
+      try (var os = t.getResponseBody()) {
         os.write(response);
       }
     });


### PR DESCRIPTION
The `var` keyword was introduced in Java 10, but this sample can make more use of it.
Also, the `try` -with-resource construct can take a `var` as well, only since Java 11.
The `(var t)` construct for lambda expressions is also from Java 11, but it's more verbose than the simple `t ->` notation, so I don't think it's worth using `var` there.